### PR TITLE
Fixed: min width of technical report div container. Keeps the h1 titl…

### DIFF
--- a/src/components/paperCard/paperCard.jsx
+++ b/src/components/paperCard/paperCard.jsx
@@ -8,6 +8,7 @@ const CardDiv = styled.div`
   margin: 3px;
   padding-top: 3px;
   vertical-align: baseline;
+  min-width: 168px;
 `;
 
 const CardImage = styled.img`


### PR DESCRIPTION
…e from turning into two lines